### PR TITLE
Add support for CTAN package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ bibparse
 dumpnames
 
 # Other
+biber-linux/
+biber-linux.tar.gz
 package/biber-linux.tar.gz
 package/biber-linux_aarch64.tar.gz
 biber-linux_aarch64.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,6 @@ package: $(BIBER_ARCHIVE)
 
 $(BIBER_ARCHIVE): $(BIBER_BINARY)
 	tar czf $(BIBER_ARCHIVE) $^
+
+ctan: test
+	./biberpackage.sh

--- a/biberpackage.sh
+++ b/biberpackage.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+BIBER_VERSION=$(docker run --rm -v $(pwd):/usr/local/bin debian:stable-slim /usr/local/bin/biber --version | sed "s,biber version: \([[:digit:]]\+\.[[:digit:]]\+\).*,\1,")
+PRODUCT=biber
+METAPLATFORM=linux
+METAPLATFORM_DIR=${PRODUCT}-${METAPLATFORM}
+ARCHIVE=${PRODUCT}-${BIBER_VERSION}-${METAPLATFORM}_aarch64.tar.gz
+
+rm -rf ${METAPLATFORM_DIR}
+mkdir -p ${METAPLATFORM_DIR}
+tar cf ${METAPLATFORM_DIR}/${ARCHIVE} biber
+
+cat >${METAPLATFORM_DIR}/README <<EOF
+These are biber binaries for the ${METAPLATFORM} platform.
+See https://ctan.org/pkg/biber for documentation, sources, and all else.
+EOF
+
+tar czf ${METAPLATFORM_DIR}.tar.gz ${METAPLATFORM_DIR}
+


### PR DESCRIPTION
Adds new make goal and the infrastructure to create a package that conforms to the standards required by CTAN (see https://github.com/plk/biber/blob/dev/BUILDERS.README for details)

Call "make ctan" to build the whole package from scratch.

With this, we can approach @plk to add this build as a regular contribution.