### PR TITLE
Reuse image on Dockerhub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@ all: test
 image:
 	docker build $(CACHE_OPTION) -f Dockerfile.build --tag sbrass/biber-aarch64 .
 
-$(BIBER_BINARY): image
-	docker run --rm -v $(PWD):/opt sbrass/biber-aarch64 $(BRANCH) $(REPO)
+$(BIBER_BINARY): 
+	docker run --rm -v $(PWD):/opt sbrass/biber-aarch64:v2.20 $(BRANCH) $(REPO)
 
 test-image:
 	docker build $(CACHE_OPTION) -f Dockerfile.test --tag sbrass/biber-test .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 BIBER_BINARY := biber
 BIBER_ARCHIVE := biber-linux_aarch64.tar.gz
 OTHER_BINARIES := biblex bibparse dumpnames
+DOCKER_TAG ?= latest
 
 .PHONY: all image biber test test-image clean upload package
 
@@ -10,7 +11,7 @@ image:
 	docker build $(CACHE_OPTION) -f Dockerfile.build --tag sbrass/biber-aarch64 .
 
 $(BIBER_BINARY): 
-	docker run --rm -v $(PWD):/opt sbrass/biber-aarch64:v2.20 $(BRANCH) $(REPO)
+	echo docker run --rm -v $(PWD):/opt sbrass/biber-aarch64:$(DOCKER_TAG) $(BRANCH) $(REPO)
 
 test-image:
 	docker build $(CACHE_OPTION) -f Dockerfile.test --tag sbrass/biber-test .

--- a/README.adoc
+++ b/README.adoc
@@ -29,6 +29,8 @@ make BRANCH="..." REPO="..." all
 The environment variables `BRANCH` and `REPO` allow to access a specific version or the development branch of the repository found at `https://github.com/REPO`.
 `BRANCH` defaults to `dev` and `REPO` to `plk/biber`.
 
+Furthermore, the environment variable `DOCKER_TAG` specifies which tag for the Docker image `sbrass/biber-aarch64` will be used. `DOCKER_TAG` defaults to `latest`. The maintainers will keep the version tags of the Docker image in sync with the tags used in this repo. This, in turn, is related to the tag used in the `plk/biber` repo.
+
 == Uploading
 
 The `biber` binary is packed as `biber-linux_aarch64.tar.gz` and needs to be wrapped in another archive with the readme from `package/README`.


### PR DESCRIPTION
No need to build the entire image unless the underlying Perl version or the libs require updates